### PR TITLE
Fixes button's double bottom border caused by the link's underline.

### DIFF
--- a/scss/partials/_button.scss
+++ b/scss/partials/_button.scss
@@ -5,6 +5,7 @@
 
 [class^="button"] {
   @extend [class^="tertiary-info"];
+  background: none;
   text-decoration: none;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/5826750/134200710-0ab4a778-c019-49cd-9793-91bc0fcf3ce2.png)

Fix:

![image](https://user-images.githubusercontent.com/5826750/134200808-1b3cc822-a3b1-4898-8af2-9b5f237c6c90.png)
