### PR TITLE
Content-slider: Fixes broken .svg icon path by moving the .svg values to the .scss file

### DIFF
--- a/public/img/cursor-carousel-arrow-back.svg
+++ b/public/img/cursor-carousel-arrow-back.svg
@@ -1,5 +1,0 @@
-<svg width="75" height="75" viewBox="0 0 75 75" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="37.5" cy="37.5" r="37.5" transform="rotate(-180 37.5 37.5)" fill="#509E2F"/>
-<line x1="53" y1="38" x2="33" y2="38" stroke="white" stroke-width="2"/>
-<path d="M21 37.5L33.75 30.1388L33.75 44.8612L21 37.5Z" fill="white"/>
-</svg>

--- a/public/img/cursor-carousel-arrow-forward.svg
+++ b/public/img/cursor-carousel-arrow-forward.svg
@@ -1,5 +1,0 @@
-<svg width="75" height="75" viewBox="0 0 75 75" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="37.5" cy="37.5" r="37.5" fill="#509E2F"/>
-<line x1="22" y1="37" x2="42" y2="37" stroke="white" stroke-width="2"/>
-<path d="M54 37.5L41.25 44.8612L41.25 30.1388L54 37.5Z" fill="white"/>
-</svg>

--- a/scss/partials/_content-slider.scss
+++ b/scss/partials/_content-slider.scss
@@ -53,12 +53,12 @@
 * TODO: might neeed to adjust the cursors x and y in relation to the arrow images
 */
       &-left {
-        cursor: url("/img/cursor-carousel-arrow-back.svg"), auto;
+        cursor: url("data:image/svg+xml,%3Csvg width='75' height='75' viewBox='0 0 75 75' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='37.5' cy='37.5' r='37.5' transform='rotate(-180 37.5 37.5)' fill='%23509E2F'/%3E%3Cline x1='53' y1='38' x2='33' y2='38' stroke='white' stroke-width='2'/%3E%3Cpath d='M21 37.5L33.75 30.1388L33.75 44.8612L21 37.5Z' fill='white'/%3E%3C/svg%3E%0A"), auto;
         width: 50%;
       }
 
       &-right {
-        cursor: url("/img/cursor-carousel-arrow-forward.svg"), auto;
+        cursor: url("data:image/svg+xml,%3Csvg width='75' height='75' viewBox='0 0 75 75' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='37.5' cy='37.5' r='37.5' fill='%23509E2F'/%3E%3Cline x1='22' y1='37' x2='42' y2='37' stroke='white' stroke-width='2'/%3E%3Cpath d='M54 37.5L41.25 44.8612L41.25 30.1388L54 37.5Z' fill='white'/%3E%3C/svg%3E%0A"), auto;
         right: 0;
         width: 50%;
       }


### PR DESCRIPTION
This .svg to CSS url (...) encoder is really neat.

[https://yoksel.github.io/url-encoder/](https://yoksel.github.io/url-encoder/)