### PR TITLE
WEB-9718: Safari - Main Nav issues

### DIFF
--- a/scss/partials/_hero.scss
+++ b/scss/partials/_hero.scss
@@ -208,7 +208,7 @@
       grid-row: 1/2;
       justify-self: start;
       padding: 0 $grid-desktop-margin;
-      z-index: 10;
+      z-index: 9;
 
       @include breakpoint(desktop) {
         align-self: center;

--- a/scss/partials/_menu.scss
+++ b/scss/partials/_menu.scss
@@ -247,6 +247,10 @@
     padding: 2.4rem 0;
     position: relative;
 
+    &::-webkit-details-marker {
+      display: none;
+    }
+
     &::before {
       @include arrow-sym(right, $secondary-green-1);
       right: 0;


### PR DESCRIPTION
✅  Z-Index clash with Main Nav

❌  Main Nav menu not resetting after closing (it "remembers" where you were last looking when you reopen the Main Nav) 
< That looks to have been already addressed by [asyncDropdown](https://github.com/aquent/vt-pattern-library/blob/15f61f9eaaea611f3b972b0fd2c5f266859c2b84/js/menu.js#L32-L47).

❌ Clicking into Main Nav should disable rest of page (see screenshot (3) with Main Nav seemingly blending with white of job page). < Moved to a separate task - [WEB-9734](https://jira.aquent.io/browse/WEB-9734)

✅ Details arrow thing (this also applies to Chrome) < also seeing it on desktop < the Chrome bit was resolved with a browser update~~