### PR TITLE
WEB-9781: Staffing & Recruiting Feedback Part-2

### DIFF
--- a/scss/partials/_tabs-panel.scss
+++ b/scss/partials/_tabs-panel.scss
@@ -5,11 +5,6 @@
 
 /// END TABLE OF CONTENTS **/
 
-/** TODO:
-* [ ] Chevron for the mobile dropdown
-*
-** 
-
 /** 1 - Tabs Panel
 ------------------------------------------------------------*/
 .tabs-nav {
@@ -43,8 +38,6 @@
       display: grid;
       grid-template-columns: repeat(7, 1fr);
       margin: 9.4 rem 0 12rem 0;
-      // margin-bottom: 12rem;
-      // margin-top: 9rem;
 
       &__li {
         align-items: flex-end;

--- a/scss/partials/_tabs-panel.scss
+++ b/scss/partials/_tabs-panel.scss
@@ -14,6 +14,7 @@
 ------------------------------------------------------------*/
 .tabs-nav {
   border-bottom: 1px solid $cool-neutral-4;
+  margin-top: 4.5rem;
   padding-bottom: 2rem;
 
   @include breakpoint(desktop) {
@@ -41,7 +42,9 @@
       border-bottom: 1px solid $cool-neutral-4;
       display: grid;
       grid-template-columns: repeat(7, 1fr);
-      margin-bottom: 12rem;
+      margin: 9.4 rem 0 12rem 0;
+      // margin-bottom: 12rem;
+      // margin-top: 9rem;
 
       &__li {
         align-items: flex-end;

--- a/scss/partials/_tabs-panel.scss
+++ b/scss/partials/_tabs-panel.scss
@@ -26,6 +26,7 @@
     // Needed to overide default <a> styles
     &__li > a {
       color: $secondary-blue-1;
+      font-weight: 600;
     }
    // reset styles set in base.scss line 180
     & > li + li {


### PR DESCRIPTION
- [x] - ! The font weight for the tab view should be ‘Para Body Emphasis.’ It should only be ‘Para Body’ when it collapses to a dropdown
- [x] - ~! For some reason, the Gaming table has a massive “LEARN MORE” link in the headline area. That should not be there. If we need to drive to gaming, Content & Creative need to discuss determine the correct UI/link treatment~ 
-> Addressed in https://github.com/aquent/vt-pattern-library/pull/156
- [x] - ! The intended vertical spacing below “Here are some of the roles we fill:” and above the dropdown menu almost doesn’t exist on mobile. Please reference t he comp
- [x] - ! Description ‘Para Body Copy’ has varying weights (i.e. the description copy under Global Talent Network is thin, and the description copy under Recruiting Expertise is thicker. Please update
-> Resolved in copy. 
- [x] - ! Sub-headlines are way too small. They should be ‘Header 4’ sized on mobile. This appears to be an issue in all Basic Content blocks like this
-> Looks to have been addressed by prior work. 