### PR TITLE
WEB-9797: Horizontal spacing on filter bar too wide for mobile

### DIFF
--- a/scss/partials/_filter-bar.scss
+++ b/scss/partials/_filter-bar.scss
@@ -1,5 +1,5 @@
 .filter-bar {
-  padding: 0 2rem;
+  padding: 0 3rem;
 
   &__content {
     display: flex;
@@ -8,7 +8,6 @@
     width: 100%;
 
     @include breakpoint(desktop) {
-      padding: 0 3rem;
       position: relative;
     }
 

--- a/scss/partials/_filter-bar.scss
+++ b/scss/partials/_filter-bar.scss
@@ -3,7 +3,7 @@
 
   &__content {
     display: flex;
-    padding: 0 3rem;
+    padding: 0 2rem;
     height: 100%;
     width: 100%;
 

--- a/scss/partials/_filter-bar.scss
+++ b/scss/partials/_filter-bar.scss
@@ -1,5 +1,5 @@
 .filter-bar {
-  padding: 0 3rem;
+  padding: 0 2rem;
 
   &__content {
     display: flex;
@@ -8,6 +8,7 @@
     width: 100%;
 
     @include breakpoint(desktop) {
+      padding: 0 3rem;
       position: relative;
     }
 


### PR DESCRIPTION
Reverts aquent/vt-pattern-library#179