### PR TITLE
WEB-9707: Home page headline wraps to an orphan in fullscreen

### DIFF
--- a/components/template/hero/hero-video.hbs
+++ b/components/template/hero/hero-video.hbs
@@ -1,9 +1,8 @@
 <div class="hero-video__section section--bg-prim-blue">
   <section class="hero-video">
     <div class="hero-video__copy">
-      <h1 class="hero-video__title">We help people and organizations grow and
-        succeed.</h1>
-      <p class="hero-video__text">We’re at the intersection of people and tech.</p>
+      <h1 class="hero-video__title">Making work less work. Every&nbsp;day.</h1>
+      <p class="hero-video__text">We bring together the right relationships and the power of technology to transform work for the better—for everyone.</p>
     </div><!-- .hero-video__copy -->
 
     <div class="hero-video__media">

--- a/scss/partials/_hero.scss
+++ b/scss/partials/_hero.scss
@@ -68,7 +68,7 @@
         justify-self: start;
         align-self: center;
         order: 1;
-        grid-column: 1/5;
+        grid-column: 1/6;
         padding-left: 3rem;
       }
     }


### PR DESCRIPTION
In addition to increasing the columns occupied by the heading text. A `&nbsp;` between "Every" and "day" has been added to the copy. 